### PR TITLE
chore: add newsletter API observability and diagnostics

### DIFF
--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -5,47 +5,177 @@ import {
   getNewsletterStatus,
 } from "@/lib/newsletter-config";
 
-const missingConfigError = {
-  error:
-    "Newsletter subscriptions are currently unavailable due to missing configuration.",
-  code: "NEWSLETTER_NOT_CONFIGURED",
-};
+type ErrorCategory = "provider" | "missing-config" | "api-failure";
+type LogLevel = "info" | "warn" | "error";
+
+interface ErrorDescriptor {
+  category: ErrorCategory;
+  code: string;
+  status: number;
+  error: string;
+}
+
+const userFacingUnavailableMessage =
+  "Newsletter subscriptions are currently unavailable due to missing configuration.";
+
+const errorByPath = {
+  providerUnavailable: {
+    category: "provider",
+    code: "NEWSLETTER_PROVIDER_UNAVAILABLE",
+    status: 503,
+    error: userFacingUnavailableMessage,
+  },
+  missingConfig: {
+    category: "missing-config",
+    code: "NEWSLETTER_NOT_CONFIGURED",
+    status: 503,
+    error: userFacingUnavailableMessage,
+  },
+  providerApiFailure: {
+    category: "api-failure",
+    code: "NEWSLETTER_PROVIDER_API_ERROR",
+    status: 502,
+    error: "There was an error subscribing to the list",
+  },
+} as const satisfies Record<string, ErrorDescriptor>;
+
+function logNewsletter(
+  level: LogLevel,
+  event: string,
+  {
+    provider,
+    configured,
+    errorCategory,
+    errorCode,
+    responseStatus,
+  }: {
+    provider: string | null;
+    configured: boolean;
+    errorCategory?: ErrorCategory;
+    errorCode?: string;
+    responseStatus?: number;
+  },
+) {
+  const payload = {
+    event,
+    provider,
+    configured,
+    errorCategory,
+    errorCode,
+    responseStatus,
+  };
+
+  if (level === "error") {
+    console.error("[newsletter-api]", payload);
+    return;
+  }
+  if (level === "warn") {
+    console.warn("[newsletter-api]", payload);
+    return;
+  }
+  console.info("[newsletter-api]", payload);
+}
+
+function jsonErrorResponse(errorDescriptor: ErrorDescriptor) {
+  return NextResponse.json(
+    {
+      error: errorDescriptor.error,
+      code: errorDescriptor.code,
+      category: errorDescriptor.category,
+    },
+    { status: errorDescriptor.status },
+  );
+}
 
 export async function GET() {
   const status = getNewsletterStatus();
 
   if (!status.configured) {
+    const descriptor = status.provider
+      ? errorByPath.missingConfig
+      : errorByPath.providerUnavailable;
+    logNewsletter("warn", "newsletter.get.unavailable", {
+      provider: status.provider,
+      configured: status.configured,
+      errorCategory: descriptor.category,
+      errorCode: descriptor.code,
+      responseStatus: 200,
+    });
+
     return NextResponse.json({
       configured: false,
       provider: status.provider,
-      message: missingConfigError.error,
+      message: descriptor.error,
+      category: descriptor.category,
+      code: descriptor.code,
     });
   }
+
+  logNewsletter("info", "newsletter.get.available", {
+    provider: status.provider,
+    configured: status.configured,
+    responseStatus: 200,
+  });
 
   return NextResponse.json({ configured: true, provider: status.provider });
 }
 
 export async function POST(request: NextRequest) {
   const provider = getNewsletterProvider();
+  const status = getNewsletterStatus();
+
+  logNewsletter("info", "newsletter.post.received", {
+    provider,
+    configured: status.configured,
+  });
 
   if (!provider) {
-    return NextResponse.json(missingConfigError, { status: 503 });
+    const descriptor = errorByPath.providerUnavailable;
+    logNewsletter("warn", "newsletter.post.failed", {
+      provider: null,
+      configured: false,
+      errorCategory: descriptor.category,
+      errorCode: descriptor.code,
+      responseStatus: descriptor.status,
+    });
+    return jsonErrorResponse(descriptor);
   }
 
-  const status = getNewsletterStatus();
   if (!status.configured) {
-    return NextResponse.json(missingConfigError, { status: 503 });
+    const descriptor = errorByPath.missingConfig;
+    logNewsletter("warn", "newsletter.post.failed", {
+      provider,
+      configured: false,
+      errorCategory: descriptor.category,
+      errorCode: descriptor.code,
+      responseStatus: descriptor.status,
+    });
+    return jsonErrorResponse(descriptor);
   }
 
   if (provider === "buttondown") {
     const { email } = (await request.json()) as { email?: string };
     if (!email) {
-      return NextResponse.json({ error: "Email is required" }, { status: 400 });
+      logNewsletter("warn", "newsletter.post.failed", {
+        provider,
+        configured: true,
+        errorCategory: "provider",
+        errorCode: "NEWSLETTER_EMAIL_REQUIRED",
+        responseStatus: 400,
+      });
+      return NextResponse.json(
+        {
+          error: "Email is required",
+          code: "NEWSLETTER_EMAIL_REQUIRED",
+          category: "provider",
+        },
+        { status: 400 },
+      );
     }
 
-    const response = await fetch(
-      "https://api.buttondown.email/v1/subscribers",
-      {
+    let response: Response;
+    try {
+      response = await fetch("https://api.buttondown.email/v1/subscribers", {
         method: "POST",
         headers: {
           Authorization: `Token ${process.env.BUTTONDOWN_API_KEY}`,
@@ -55,8 +185,18 @@ export async function POST(request: NextRequest) {
           email_address: email,
           type: "regular",
         }),
-      },
-    );
+      });
+    } catch {
+      const descriptor = errorByPath.providerApiFailure;
+      logNewsletter("error", "newsletter.post.failed", {
+        provider,
+        configured: true,
+        errorCategory: descriptor.category,
+        errorCode: descriptor.code,
+        responseStatus: descriptor.status,
+      });
+      return jsonErrorResponse(descriptor);
+    }
 
     let providerBody: { code?: string } | null = null;
     try {
@@ -66,6 +206,11 @@ export async function POST(request: NextRequest) {
     }
 
     if (providerBody?.code === "email_already_exists") {
+      logNewsletter("info", "newsletter.post.already-subscribed", {
+        provider,
+        configured: true,
+        responseStatus: 200,
+      });
       return NextResponse.json(
         {
           message: "You're already subscribed.",
@@ -75,17 +220,56 @@ export async function POST(request: NextRequest) {
     }
 
     if (response.status >= 400) {
-      return NextResponse.json(
-        { error: "There was an error subscribing to the list" },
-        { status: response.status },
-      );
+      const descriptor = errorByPath.providerApiFailure;
+      logNewsletter("error", "newsletter.post.failed", {
+        provider,
+        configured: true,
+        errorCategory: descriptor.category,
+        errorCode: providerBody?.code || descriptor.code,
+        responseStatus: response.status,
+      });
+      return jsonErrorResponse({ ...descriptor, status: response.status });
     }
 
+    logNewsletter("info", "newsletter.post.success", {
+      provider,
+      configured: true,
+      responseStatus: 201,
+    });
     return NextResponse.json(
       { message: "Successfully subscribed to the newsletter" },
       { status: 201 },
     );
   }
 
-  return NewsletterAPI(request, { provider });
+  try {
+    const response = await NewsletterAPI(request, { provider });
+    if (response.status >= 400) {
+      const descriptor = errorByPath.providerApiFailure;
+      logNewsletter("error", "newsletter.post.failed", {
+        provider,
+        configured: true,
+        errorCategory: descriptor.category,
+        errorCode: descriptor.code,
+        responseStatus: response.status,
+      });
+    } else {
+      logNewsletter("info", "newsletter.post.success", {
+        provider,
+        configured: true,
+        responseStatus: response.status,
+      });
+    }
+    return response;
+  } catch {
+    const descriptor = errorByPath.providerApiFailure;
+    logNewsletter("error", "newsletter.post.failed", {
+      provider,
+      configured: true,
+      errorCategory: descriptor.category,
+      errorCode: descriptor.code,
+      responseStatus: descriptor.status,
+    });
+    return jsonErrorResponse(descriptor);
+  }
 }

--- a/docs/runbooks/newsletter-observability.md
+++ b/docs/runbooks/newsletter-observability.md
@@ -1,0 +1,59 @@
+# Newsletter API Observability Runbook
+
+This runbook explains the structured logs emitted by `app/api/newsletter/route.ts`.
+
+## Log format
+
+All newsletter API logs are emitted with a stable prefix and JSON payload:
+
+- Prefix: `[newsletter-api]`
+- Fields:
+  - `event`: event name
+  - `provider`: configured provider name or `null`
+  - `configured`: whether provider + required env are configured
+  - `errorCategory`: one of `provider`, `missing-config`, `api-failure` (present on failures)
+  - `errorCode`: stable diagnostic code (present on failures)
+  - `responseStatus`: HTTP status returned to client
+
+Logs intentionally exclude secrets and user-provided email values.
+
+## Event reference
+
+- `newsletter.get.available`: GET health/status check confirms configuration is usable.
+- `newsletter.get.unavailable`: GET status shows provider is unavailable or misconfigured.
+- `newsletter.post.received`: POST subscribe request reached API.
+- `newsletter.post.success`: subscription succeeded.
+- `newsletter.post.already-subscribed`: provider reported duplicate email.
+- `newsletter.post.failed`: subscribe request failed.
+
+## Error categories and codes
+
+- `provider`
+  - `NEWSLETTER_PROVIDER_UNAVAILABLE`: provider is missing/unsupported.
+  - `NEWSLETTER_EMAIL_REQUIRED`: request payload omitted email.
+- `missing-config`
+  - `NEWSLETTER_NOT_CONFIGURED`: provider exists but required env vars are missing.
+- `api-failure`
+  - `NEWSLETTER_PROVIDER_API_ERROR`: provider request failed (network or provider HTTP error).
+  - Provider-specific API codes may appear in `errorCode` when safely available.
+
+## Manual verification checklist
+
+1. Configured success path
+- Set valid provider env vars.
+- `GET /api/newsletter` should log `newsletter.get.available`.
+- `POST /api/newsletter` with valid email should log `newsletter.post.received` then `newsletter.post.success`.
+
+2. Missing provider / unsupported provider path
+- Set `siteMetadata.newsletter.provider` to an unsupported value.
+- `GET /api/newsletter` should log `newsletter.get.unavailable` with `errorCategory=provider`.
+- `POST /api/newsletter` should log `newsletter.post.failed` with `errorCode=NEWSLETTER_PROVIDER_UNAVAILABLE`.
+
+3. Missing env configuration path
+- Use a supported provider but remove required env vars.
+- `GET /api/newsletter` should log `newsletter.get.unavailable` with `errorCategory=missing-config`.
+- `POST /api/newsletter` should log `newsletter.post.failed` with `errorCode=NEWSLETTER_NOT_CONFIGURED`.
+
+4. Provider API failure path
+- Keep provider configured but force provider failure (invalid provider key or temporary outage).
+- `POST /api/newsletter` should log `newsletter.post.failed` with `errorCategory=api-failure` and `responseStatus>=400`.


### PR DESCRIPTION
## Summary
- Added structured observability logging for newsletter API GET/POST flows in `app/api/newsletter/route.ts`.
- Standardized diagnostics for provider, missing-config, and provider API failure paths using stable `category` and `code` fields.
- Added a concise runbook for interpreting newsletter API logs and validating common failure modes.

## PR Title
- Format: `feat|chore|bug: <short description>`
- Using: `chore: add newsletter API observability and diagnostics`

## Linked Issue
- Closes #21

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Chore / Tooling / CI
- [x] Documentation only

## Scope
- In scope: API observability and error diagnostics in newsletter route, plus runbook docs.
- Out of scope: major UI behavior/copy changes, provider integration rewrites.

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] Additional tests/checks: verified logs include only safe diagnostic fields (provider/configured/category/code/status).
- [x] Manual smoke checks: documented in `docs/runbooks/newsletter-observability.md` for success/missing-config/provider/API-failure paths.

## Checklist
- [ ] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: downstream consumers relying on previous error body shape may need to ignore new `category`/`code` fields.
- Rollback plan: Revert commit `1572f57`.

## Migration Notes (if breaking)
- N/A

## Screenshots / Evidence (if UI change)
- Before: N/A
- After: N/A
