### PR TITLE
chore: suppress no-img lint warning in og route

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -77,6 +77,8 @@ export async function GET(request: Request) {
             }}
           >
             {/* Image */}
+            {/* next/image is not supported inside next/og ImageResponse markup. */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={imageSource}
               alt="blog post banner"


### PR DESCRIPTION
## Summary
- Added a scoped lint suppression for the OG route `<img>` element in `app/api/og/route.tsx`.
- This resolves the recurring `@next/next/no-img-element` warning in the OG `ImageResponse` context where `next/image` is not supported.
- OG route rendering and behavior are unchanged.

## PR Title
- Format: `feat|chore|bug: <short description>`
- `chore: suppress no-img lint warning in og route`

## Linked Issue
- Closes #34

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Chore / Tooling / CI
- [ ] Documentation only

## Scope
- In scope: Explicitly handle `no-img` lint in OG route with a local suppression and rationale.
- Out of scope: Any OG visual/layout/content updates or API behavior changes.

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] Additional tests/checks: Confirmed no `@next/next/no-img-element` warning is reported for `app/api/og/route.tsx`.
- [x] Manual smoke checks: N/A (no UI behavior change).

## Checklist
- [x] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: Minimal; change is lint-only annotation in a single route file.
- Rollback plan: Revert commit `4d3bce9`.

## Migration Notes (if breaking)
- N/A

## Screenshots / Evidence (if UI change)
- Before: N/A
- After: N/A
