### PR TITLE
chore: stabilize contentlayer prebuild behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "next dev",
     "dev": "cross-env INIT_CWD=$PWD next dev",
-    "prebuild": "cross-env INIT_CWD=$PWD contentlayer build || true && node scripts/patch-contentlayer-json-imports.mjs",
+    "prebuild": "node scripts/run-contentlayer-build.mjs && node scripts/patch-contentlayer-json-imports.mjs",
     "build": "cross-env INIT_CWD=$PWD SKIP_CONTENTLAYER=true next build && node ./scripts/postbuild.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",

--- a/scripts/run-contentlayer-build.mjs
+++ b/scripts/run-contentlayer-build.mjs
@@ -1,5 +1,16 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const siteMetadata = require('../data/siteMetadata.js')
+
+const GENERATED_INDEX_PATH = '.contentlayer/generated/index.mjs'
+const GENERATED_TAG_DATA_PATH = 'app/blog/tag-data.json'
+const GENERATED_SEARCH_INDEX_PATH =
+  siteMetadata?.search?.provider === 'kbar' && siteMetadata?.search?.kbarConfig?.searchDocumentsPath
+    ? `public/${siteMetadata.search.kbarConfig.searchDocumentsPath}`
+    : null
 
 const child = spawn(
   process.platform === 'win32' ? 'npx.cmd' : 'npx',
@@ -11,31 +22,76 @@ const child = spawn(
   }
 )
 
-let combinedOutput = ''
+let stdout = ''
+let stderr = ''
 
 const forward = (stream, target) => {
   stream.on('data', (chunk) => {
     const text = chunk.toString()
-    combinedOutput += text
-    target.write(text)
+    if (target === process.stdout) {
+      stdout += text
+    } else {
+      stderr += text
+    }
   })
 }
 
 forward(child.stdout, process.stdout)
 forward(child.stderr, process.stderr)
 
+function sanitizeOutput(output, { suppressKnownExitBug = false } = {}) {
+  let sanitized = output
+    .replace(/^\(node:\d+\) \[DEP0040\][^\n]*\n?/gm, '')
+    .replace(
+      /^\(Use `node --trace-deprecation \.\.\.` to show where the warning was created\)\n?/gm,
+      ''
+    )
+    .replace(/^successCallback[^\n]*\n?/gm, '')
+
+  if (suppressKnownExitBug) {
+    sanitized = sanitized.replace(
+      /TypeError: The "code" argument must be of type number\.[\s\S]*?code: 'ERR_INVALID_ARG_TYPE'\s*\}\n?/g,
+      ''
+    )
+  }
+
+  return sanitized
+}
+
 child.on('exit', (code) => {
-  const generatedIndexPath = '.contentlayer/generated/index.mjs'
-  const generatedTagDataPath = 'app/blog/tag-data.json'
-  const hasGeneratedArtifacts =
-    existsSync(generatedIndexPath) && existsSync(generatedTagDataPath)
+  const combinedOutput = `${stdout}\n${stderr}`
+  const generatedArtifacts = [
+    GENERATED_INDEX_PATH,
+    GENERATED_TAG_DATA_PATH,
+    GENERATED_SEARCH_INDEX_PATH,
+  ].filter(Boolean)
+  const missingArtifacts = generatedArtifacts.filter((artifactPath) => !existsSync(artifactPath))
+  const hasGeneratedArtifacts = missingArtifacts.length === 0
   const hasKnownExitBug =
     combinedOutput.includes('Generated ') &&
     combinedOutput.includes('documents in .contentlayer') &&
     combinedOutput.includes('ERR_INVALID_ARG_TYPE')
 
+  process.stdout.write(
+    sanitizeOutput(stdout, { suppressKnownExitBug: hasKnownExitBug && hasGeneratedArtifacts })
+  )
+  process.stderr.write(
+    sanitizeOutput(stderr, { suppressKnownExitBug: hasKnownExitBug && hasGeneratedArtifacts })
+  )
+
   if (code === 0 || (hasKnownExitBug && hasGeneratedArtifacts)) {
+    if (hasKnownExitBug) {
+      process.stdout.write(
+        `Contentlayer completed successfully. Verified artifacts: ${generatedArtifacts.join(', ')}\n`
+      )
+    }
     process.exit(0)
+  }
+
+  if (missingArtifacts.length > 0) {
+    process.stderr.write(
+      `Contentlayer build did not produce required artifacts: ${missingArtifacts.join(', ')}\n`
+    )
   }
 
   process.exit(code ?? 1)


### PR DESCRIPTION
## Summary
- replace the permissive `contentlayer build || true` prebuild flow with the dedicated wrapper script so real failures are no longer masked
- treat Contentlayer's known `ERR_INVALID_ARG_TYPE` CLI exit bug as success only when the expected generated artifacts exist
- keep artifact generation intact for Contentlayer output, tag data, and the local search index while removing recurring warning/error noise from successful prebuild logs

## PR Title
- `chore: stabilize contentlayer prebuild behavior`

## Linked Issue
- Closes #31

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Chore / Tooling / CI
- [ ] Documentation only

## Scope
- In scope: prebuild script wiring, Contentlayer success/failure handling, artifact verification, log cleanup for the known false-negative exit path
- Out of scope: content model changes, schema redesign, unrelated lint/build warnings

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] Additional tests/checks: `npm run prebuild`
- [x] Manual smoke checks: confirmed clean prebuild logs and verified `.contentlayer/generated/index.mjs`, `app/blog/tag-data.json`, and `public/search.json` are produced

## Checklist
- [ ] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: the wrapper could incorrectly classify a Contentlayer run if artifact expectations drift in the future; current checks are limited to the artifacts this app depends on today
- Rollback plan: Revert commit(s) `10fba6a`

## Migration Notes (if breaking)
- N/A

## Screenshots / Evidence (if UI change)
- Before: N/A
- After: `npm run prebuild` logs `Local search index generated...`, `Generated 11 documents in .contentlayer`, and explicit artifact verification without the previous ambiguous stack trace
