### PR TITLE
chore: standardize newsletter fallback and error copy

### DIFF
--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -4,6 +4,7 @@ import {
   getNewsletterProvider,
   getNewsletterStatus,
 } from "@/lib/newsletter-config";
+import { newsletterMessages } from "@/lib/newsletter-messages";
 
 type ErrorCategory = "provider" | "missing-config" | "api-failure";
 type LogLevel = "info" | "warn" | "error";
@@ -15,8 +16,7 @@ interface ErrorDescriptor {
   error: string;
 }
 
-const userFacingUnavailableMessage =
-  "Newsletter subscriptions are currently unavailable due to missing configuration.";
+const userFacingUnavailableMessage = newsletterMessages.unavailable;
 
 const errorByPath = {
   providerUnavailable: {
@@ -35,7 +35,7 @@ const errorByPath = {
     category: "api-failure",
     code: "NEWSLETTER_PROVIDER_API_ERROR",
     status: 502,
-    error: "There was an error subscribing to the list",
+    error: newsletterMessages.providerApiError,
   },
 } as const satisfies Record<string, ErrorDescriptor>;
 
@@ -165,7 +165,7 @@ export async function POST(request: NextRequest) {
       });
       return NextResponse.json(
         {
-          error: "Email is required",
+          error: newsletterMessages.emailRequired,
           code: "NEWSLETTER_EMAIL_REQUIRED",
           category: "provider",
         },
@@ -213,7 +213,7 @@ export async function POST(request: NextRequest) {
       });
       return NextResponse.json(
         {
-          message: "You're already subscribed.",
+          message: newsletterMessages.alreadySubscribed,
         },
         { status: 200 },
       );
@@ -237,7 +237,7 @@ export async function POST(request: NextRequest) {
       responseStatus: 201,
     });
     return NextResponse.json(
-      { message: "Successfully subscribed to the newsletter" },
+      { message: newsletterMessages.subscribed },
       { status: 201 },
     );
   }

--- a/components/newsletter-cta.tsx
+++ b/components/newsletter-cta.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import siteMetadata from '@/data/siteMetadata'
+import { newsletterMessages } from '@/lib/newsletter-messages'
 
 type ViewState = 'idle' | 'success' | 'error' | 'missing-config'
 
@@ -15,10 +16,9 @@ const supportedProviders = new Set([
   'emailoctopus',
 ])
 
-const defaultErrorMessage = 'Unable to subscribe right now. Please try again later.'
-const defaultMissingConfigMessage =
-  'Newsletter subscriptions are temporarily unavailable. You can still read all posts.'
-const emailValidationMessage = 'Please enter a valid email address (for example, name@example.com).'
+const defaultErrorMessage = newsletterMessages.subscribeError
+const defaultMissingConfigMessage = newsletterMessages.unavailable
+const emailValidationMessage = newsletterMessages.emailValidation
 
 interface NewsletterStatusResponse {
   configured?: boolean
@@ -133,7 +133,7 @@ export default function NewsletterCta({
         inputRef.current.value = ''
       }
       setViewState('success')
-      setFeedbackMessage(data?.message || 'Thanks for subscribing.')
+      setFeedbackMessage(data?.message || newsletterMessages.subscribed)
       router.push('/newsletter/success')
     } catch {
       setViewState('error')
@@ -196,7 +196,7 @@ export default function NewsletterCta({
         <p className="mt-3 text-sm text-secondary/80" aria-live="polite">
           {validationMessage && validationMessage}
           {viewState === 'success' && feedbackMessage}
-          {viewState === 'error' && `Subscription failed: ${feedbackMessage}`}
+          {viewState === 'error' && feedbackMessage}
           {viewState === 'missing-config' && feedbackMessage}
         </p>
       )}

--- a/docs/runbooks/newsletter-observability.md
+++ b/docs/runbooks/newsletter-observability.md
@@ -37,6 +37,23 @@ Logs intentionally exclude secrets and user-provided email values.
   - `NEWSLETTER_PROVIDER_API_ERROR`: provider request failed (network or provider HTTP error).
   - Provider-specific API codes may appear in `errorCode` when safely available.
 
+## User-facing copy map
+
+The API and CTA share `lib/newsletter-messages.ts` as the source of truth:
+
+- `unavailable`
+  - "Newsletter sign-ups are temporarily unavailable. You can still read all posts."
+- `subscribeError` / `providerApiError`
+  - "We couldn't complete your subscription. Please try again in a moment."
+- `emailValidation`
+  - "Please enter a valid email address (for example, name@example.com)."
+- `emailRequired`
+  - "Please enter your email to subscribe."
+- `subscribed`
+  - "You're subscribed. Thanks for joining."
+- `alreadySubscribed`
+  - "You're already subscribed with this email."
+
 ## Manual verification checklist
 
 1. Configured success path

--- a/lib/newsletter-messages.ts
+++ b/lib/newsletter-messages.ts
@@ -1,0 +1,9 @@
+export const newsletterMessages = {
+  unavailable: 'Newsletter sign-ups are temporarily unavailable. You can still read all posts.',
+  subscribeError: "We couldn't complete your subscription. Please try again in a moment.",
+  emailValidation: 'Please enter a valid email address (for example, name@example.com).',
+  emailRequired: 'Please enter your email to subscribe.',
+  subscribed: "You're subscribed. Thanks for joining.",
+  alreadySubscribed: "You're already subscribed with this email.",
+  providerApiError: "We couldn't complete your subscription. Please try again in a moment.",
+} as const


### PR DESCRIPTION
## Summary
Standardizes newsletter fallback/error copy across API and CTA using a single shared message source.

## Linked Issue
- Closes #32

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Chore / Tooling / CI
- [ ] Documentation only

## Scope
- In scope: unify newsletter copy for missing config, API failure, email-required, subscribed, and already-subscribed states.
- Out of scope: provider changes, behavior changes, analytics changes.

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] Additional tests/checks: Manual path review for success/error/missing-config/already-subscribed copy mapping.
- [ ] Manual smoke checks: Pending in preview.

## Checklist
- [x] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: Copy-only regressions in edge state messaging.
- Rollback plan: Revert this PR.

## Migration Notes (if breaking)
- N/A

## Screenshots / Evidence (if UI change)
- Before: N/A
- After: N/A
