### PR TITLE
chore: add local clap-store mock mode and API tests

### DIFF
--- a/app/api/claps/route.test.ts
+++ b/app/api/claps/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/claps/route";
+import { resetLocalClapStoreForTests } from "@/lib/claps-store";
+
+function requestWithCookie(
+  url: string,
+  init?: RequestInit & { cookie?: string },
+) {
+  const headers = new Headers(init?.headers);
+  if (init?.cookie) {
+    headers.set("cookie", init.cookie);
+  }
+  return new NextRequest(url, { ...init, headers });
+}
+
+describe("/api/claps", () => {
+  beforeEach(() => {
+    resetLocalClapStoreForTests();
+  });
+
+  it("returns 400 when slug is missing", async () => {
+    const request = new NextRequest("http://localhost:3000/api/claps");
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns summary for valid slug and sets visitor cookie", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/claps?slug=sample-post",
+    );
+    const response = await GET(request);
+    const body = (await response.json()) as {
+      configured: boolean;
+      total: number;
+      user: number;
+      cap: number;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.configured).toBe(true);
+    expect(body.total).toBe(0);
+    expect(body.user).toBe(0);
+    expect(body.cap).toBe(50);
+    expect(response.headers.get("set-cookie")).toContain("clap_visitor_id=");
+  });
+
+  it("increments count with same visitor and enforces cap", async () => {
+    const cookie = "clap_visitor_id=test-visitor-1";
+    for (let index = 0; index < 60; index += 1) {
+      const request = requestWithCookie("http://localhost:3000/api/claps", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ slug: "cap-check-post" }),
+        cookie,
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    }
+
+    const summaryRequest = requestWithCookie(
+      "http://localhost:3000/api/claps?slug=cap-check-post",
+      {
+        cookie,
+      },
+    );
+    const summaryResponse = await GET(summaryRequest);
+    const summaryBody = (await summaryResponse.json()) as {
+      total: number;
+      user: number;
+      cap: number;
+    };
+
+    expect(summaryBody.user).toBe(50);
+    expect(summaryBody.total).toBe(50);
+    expect(summaryBody.cap).toBe(50);
+  });
+});

--- a/lib/claps-store.test.ts
+++ b/lib/claps-store.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  addClap,
+  getClapSummary,
+  getClapsCapPerVisitor,
+  resetLocalClapStoreForTests,
+} from '@/lib/claps-store'
+
+describe('claps-store (local mock mode)', () => {
+  beforeEach(() => {
+    resetLocalClapStoreForTests()
+  })
+
+  it('starts at zero and increments counts', async () => {
+    const slug = 'sample-post'
+    const visitorId = 'visitor-a'
+
+    const initial = await getClapSummary(slug, visitorId)
+    expect(initial.configured).toBe(true)
+    expect(initial.total).toBe(0)
+    expect(initial.user).toBe(0)
+
+    const afterLike = await addClap({
+      slug,
+      visitorId,
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+    })
+
+    expect(afterLike.configured).toBe(true)
+    expect(afterLike.total).toBe(1)
+    expect(afterLike.user).toBe(1)
+    expect(afterLike.cap).toBe(getClapsCapPerVisitor())
+  })
+
+  it('enforces cap of 50 claps per visitor per post', async () => {
+    const slug = 'cap-post'
+    const visitorId = 'visitor-cap'
+
+    for (let index = 0; index < 80; index += 1) {
+      await addClap({
+        slug,
+        visitorId,
+        ip: '127.0.0.1',
+        userAgent: 'vitest',
+      })
+    }
+
+    const summary = await getClapSummary(slug, visitorId)
+    expect(summary.user).toBe(50)
+    expect(summary.total).toBe(50)
+    expect(summary.cap).toBe(50)
+  })
+
+  it('rate limits excessive writes from same fingerprint', async () => {
+    const slug = 'rate-limit-post'
+    const visitorId = 'visitor-rate-limit'
+
+    let limitedAt = -1
+    for (let index = 1; index <= 200; index += 1) {
+      const response = await addClap({
+        slug,
+        visitorId: `${visitorId}-${index}`,
+        ip: '203.0.113.10',
+        userAgent: 'bot-simulator',
+      })
+
+      if (response.limited) {
+        limitedAt = index
+        break
+      }
+    }
+
+    expect(limitedAt).toBeGreaterThan(0)
+    expect(limitedAt).toBeLessThanOrEqual(121)
+  })
+})

--- a/lib/claps-store.ts
+++ b/lib/claps-store.ts
@@ -5,7 +5,14 @@ const CLAPS_CAP_PER_VISITOR = 50
 const RATE_LIMIT_PER_MINUTE = 120
 const RATE_LIMIT_WINDOW_SECONDS = 60
 
-type ClapStoreStatus = { configured: false } | { configured: true; redis: Redis }
+const localTotals = new Map<string, number>()
+const localUsers = new Map<string, number>()
+const localRate = new Map<string, { count: number; expiresAt: number }>()
+
+type ClapStoreStatus =
+  | { configured: false }
+  | { configured: true; mode: 'redis'; redis: Redis }
+  | { configured: true; mode: 'local' }
 
 export type ClapSummary = {
   configured: boolean
@@ -15,6 +22,12 @@ export type ClapSummary = {
 }
 
 function getRedisStatus(): ClapStoreStatus {
+  const forceRemoteStore = process.env.CLAPS_USE_REMOTE_STORE === 'true'
+  const isNonProduction = process.env.NODE_ENV !== 'production'
+  if (isNonProduction && !forceRemoteStore) {
+    return { configured: true, mode: 'local' }
+  }
+
   const url = process.env.UPSTASH_REDIS_REST_URL
   const token = process.env.UPSTASH_REDIS_REST_TOKEN
 
@@ -24,6 +37,7 @@ function getRedisStatus(): ClapStoreStatus {
 
   return {
     configured: true,
+    mode: 'redis',
     redis: new Redis({
       url,
       token,
@@ -65,6 +79,12 @@ export function getClapsCapPerVisitor() {
   return CLAPS_CAP_PER_VISITOR
 }
 
+export function resetLocalClapStoreForTests() {
+  localTotals.clear()
+  localUsers.clear()
+  localRate.clear()
+}
+
 export async function getClapSummary(slug: string, visitorId: string): Promise<ClapSummary> {
   const status = getRedisStatus()
   if (!status.configured) {
@@ -72,6 +92,15 @@ export async function getClapSummary(slug: string, visitorId: string): Promise<C
       configured: false,
       total: 0,
       user: 0,
+      cap: CLAPS_CAP_PER_VISITOR,
+    }
+  }
+
+  if (status.mode === 'local') {
+    return {
+      configured: true,
+      total: localTotals.get(totalKey(slug)) || 0,
+      user: Math.min(CLAPS_CAP_PER_VISITOR, localUsers.get(userKey(slug, visitorId)) || 0),
       cap: CLAPS_CAP_PER_VISITOR,
     }
   }
@@ -110,9 +139,50 @@ export async function addClap({
     }
   }
 
-  const redis = status.redis
   const fingerprint = hashFingerprint(`${ip}|${userAgent}`)
   const rlKey = rateLimitKey(slug, fingerprint)
+  if (status.mode === 'local') {
+    const now = Date.now()
+    const existingRate = localRate.get(rlKey)
+    const activeRate =
+      existingRate && existingRate.expiresAt > now
+        ? existingRate
+        : { count: 0, expiresAt: now + RATE_LIMIT_WINDOW_SECONDS * 1000 }
+
+    const nextRate = {
+      count: activeRate.count + 1,
+      expiresAt: activeRate.expiresAt,
+    }
+    localRate.set(rlKey, nextRate)
+
+    if (nextRate.count > RATE_LIMIT_PER_MINUTE) {
+      return {
+        ...(await getClapSummary(slug, visitorId)),
+        limited: true,
+      }
+    }
+
+    const perUserKey = userKey(slug, visitorId)
+    const currentUser = localUsers.get(perUserKey) || 0
+    if (currentUser >= CLAPS_CAP_PER_VISITOR) {
+      return await getClapSummary(slug, visitorId)
+    }
+
+    const nextUserCount = currentUser + 1
+    const totalStoreKey = totalKey(slug)
+    const nextTotalCount = (localTotals.get(totalStoreKey) || 0) + 1
+    localUsers.set(perUserKey, nextUserCount)
+    localTotals.set(totalStoreKey, nextTotalCount)
+
+    return {
+      configured: true,
+      total: nextTotalCount,
+      user: Math.min(CLAPS_CAP_PER_VISITOR, nextUserCount),
+      cap: CLAPS_CAP_PER_VISITOR,
+    }
+  }
+
+  const redis = status.redis
   const rlCount = await redis.incr(rlKey)
   if (rlCount === 1) {
     await redis.expire(rlKey, RATE_LIMIT_WINDOW_SECONDS)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,22 @@
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname),
+    },
+  },
   esbuild: {
     jsx: 'automatic',
     jsxImportSource: 'react',
   },
   test: {
     environment: 'jsdom',
-    include: ['components/**/*.test.{ts,tsx}'],
+    include: [
+      'components/**/*.test.{ts,tsx}',
+      'lib/**/*.test.{ts,tsx}',
+      'app/**/*.test.{ts,tsx}',
+    ],
   },
 })


### PR DESCRIPTION
## Summary
Implements item 1 in the upgrade sequence:
- local mock clap storage in development (no Upstash writes locally by default)
- tests for clap store behavior and `/api/claps` route

## Changes
- `lib/claps-store.ts`
  - adds local in-memory store mode for non-production
  - remote Redis mode can be forced with `CLAPS_USE_REMOTE_STORE=true`
  - exports `resetLocalClapStoreForTests` for deterministic tests
- `lib/claps-store.test.ts`
  - verifies increment behavior
  - verifies per-visitor cap (50)
  - verifies rate limiting path
- `app/api/claps/route.test.ts`
  - validates missing slug (400)
  - validates summary + cookie behavior
  - validates cap behavior via repeated POSTs
- `vitest.config.ts`
  - adds `@` alias resolution
  - expands test includes to `lib/**` and `app/**`

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
