### PR TITLE
chore: improve post-end accessibility and motion controls

### DIFF
--- a/components/clap-button.tsx
+++ b/components/clap-button.tsx
@@ -38,6 +38,7 @@ export default function ClapButton({ slug }: { slug: string }) {
   const [isProcessing, setIsProcessing] = useState(false)
   const [particles, setParticles] = useState<Particle[]>([])
   const [error, setError] = useState('')
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
 
   const isAtCap = state.user >= state.cap
   const hasLiked = state.user > 0
@@ -51,6 +52,19 @@ export default function ClapButton({ slug }: { slug: string }) {
   useEffect(() => {
     stateRef.current = state
   }, [state])
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches)
+    updatePreference()
+
+    mediaQuery.addEventListener('change', updatePreference)
+    return () => mediaQuery.removeEventListener('change', updatePreference)
+  }, [])
 
   useEffect(() => {
     let isCancelled = false
@@ -88,6 +102,10 @@ export default function ClapButton({ slug }: { slug: string }) {
   const canLikeNow = !isLoading && state.configured && stateRef.current.user < stateRef.current.cap
 
   const launchBurst = (count: number, celebration = false) => {
+    if (prefersReducedMotion) {
+      return
+    }
+
     const nextParticles: Particle[] = Array.from({ length: count }).map((_, index) => {
       const angle = (Math.PI * 2 * index) / count + Math.random() * 0.25
       const distance = celebration ? 52 + Math.random() * 28 : 36 + Math.random() * 18
@@ -261,7 +279,7 @@ export default function ClapButton({ slug }: { slug: string }) {
             data-testid="like-button"
             aria-label={isAtCap ? `Like limit reached (${state.cap})` : 'Like this post'}
             aria-pressed={hasLiked}
-            className={`group relative inline-flex h-10 w-10 items-center justify-center rounded-full border text-xl leading-none transition hover:scale-105 ${
+            className={`group relative inline-flex h-10 w-10 items-center justify-center rounded-full border text-xl leading-none transition hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-2 focus-visible:ring-offset-primary ${
               hasLiked
                 ? 'bg-accent/12 hover:bg-accent/16 border-accent/45 text-accent'
                 : 'border-secondary/25 bg-transparent text-secondary hover:border-accent/40 hover:text-accent'
@@ -299,7 +317,11 @@ export default function ClapButton({ slug }: { slug: string }) {
           ))}
         </div>
 
-        <span className="text-xs font-semibold text-secondary/80" data-testid="like-count">
+        <span
+          className="text-xs font-semibold text-secondary/80"
+          data-testid="like-count"
+          aria-live="polite"
+        >
           {state.total.toLocaleString()}
         </span>
       </div>

--- a/components/newsletter-cta.tsx
+++ b/components/newsletter-cta.tsx
@@ -215,7 +215,7 @@ export default function NewsletterCta({
           type="submit"
           disabled={disableForm}
           aria-disabled={disableForm}
-          className="min-w-[10rem] rounded-md bg-accent px-5 py-2.5 font-semibold text-white transition hover:bg-accent/80 disabled:cursor-not-allowed disabled:bg-secondary/20 disabled:text-secondary/50 disabled:opacity-100"
+          className="min-w-[10rem] rounded-md bg-accent px-5 py-2.5 font-semibold text-white transition hover:bg-accent/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-primary disabled:cursor-not-allowed disabled:bg-secondary/20 disabled:text-secondary/50 disabled:opacity-100"
         >
           {viewState === 'success'
             ? 'Subscribed'

--- a/components/post-engagement-rail.tsx
+++ b/components/post-engagement-rail.tsx
@@ -33,7 +33,7 @@ export default function PostEngagementRail({ slug }: { slug: string }) {
         <button
           type="button"
           onClick={onCopyLink}
-          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-secondary/75 transition hover:bg-secondary/10 hover:text-secondary"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-secondary/75 transition hover:bg-secondary/10 hover:text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
           data-testid="copy-link-button"
           aria-label={copied ? 'Link copied' : 'Copy post link'}
           title={copied ? 'Copied' : 'Copy link'}

--- a/tests/smoke/blog.smoke.spec.ts
+++ b/tests/smoke/blog.smoke.spec.ts
@@ -89,6 +89,14 @@ test.describe('blog smoke suite', () => {
       .toBeGreaterThan(initialCount)
 
     const afterClickCount = Number((await likeCount.textContent())?.trim() || '0')
+
+    await likeButton.focus()
+    await page.keyboard.press('Enter')
+    await expect
+      .poll(async () => Number((await likeCount.textContent())?.trim() || '0'))
+      .toBeGreaterThan(afterClickCount)
+
+    const afterKeyboardCount = Number((await likeCount.textContent())?.trim() || '0')
     await likeButton.hover()
     await page.mouse.down()
     await page.waitForTimeout(900)
@@ -96,7 +104,7 @@ test.describe('blog smoke suite', () => {
 
     await expect
       .poll(async () => Number((await likeCount.textContent())?.trim() || '0'))
-      .toBeGreaterThan(afterClickCount)
+      .toBeGreaterThan(afterKeyboardCount)
 
     await copyLinkButton.click()
     await expect(copyLinkButton).toHaveAttribute('aria-label', 'Link copied')


### PR DESCRIPTION
## Summary
Implements item 3 in the sequence: accessibility and motion-quality pass for post-end components.

## Changes
- `components/clap-button.tsx`
  - adds reduced-motion detection and suppresses burst particles when `prefers-reduced-motion: reduce`
  - adds stronger focus-visible ring treatment
  - adds `aria-live="polite"` for like count updates
- `components/post-engagement-rail.tsx`
  - adds focus-visible ring on copy action
  - keeps copied feedback accessible (`aria-label` + title update)
- `components/newsletter-cta.tsx`
  - adds focus-visible ring treatment to subscribe button
- `tests/smoke/blog.smoke.spec.ts`
  - extends engagement smoke test with keyboard interaction (`Enter` on like button)

## Validation
- `npm run test:smoke:ci`
- `npm test`
- `npm run lint`
- `npm run build`
