### PR TITLE
perf: batch like increments for hold interactions

### DIFF
--- a/app/api/claps/route.test.ts
+++ b/app/api/claps/route.test.ts
@@ -79,4 +79,28 @@ describe("/api/claps", () => {
     expect(summaryBody.total).toBe(50);
     expect(summaryBody.cap).toBe(50);
   });
+
+  it("accepts batched amount in POST body", async () => {
+    const cookie = "clap_visitor_id=test-visitor-batch";
+    const request = requestWithCookie("http://localhost:3000/api/claps", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ slug: "batch-route-post", amount: 5 }),
+      cookie,
+    });
+
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      total: number;
+      user: number;
+      cap: number;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.total).toBe(5);
+    expect(body.user).toBe(5);
+    expect(body.cap).toBe(50);
+  });
 });

--- a/app/api/claps/route.ts
+++ b/app/api/claps/route.ts
@@ -91,9 +91,9 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  let body: { slug?: string } = {};
+  let body: { slug?: string; amount?: number } = {};
   try {
-    body = (await request.json()) as { slug?: string };
+    body = (await request.json()) as { slug?: string; amount?: number };
   } catch {
     return createInvalidSlugResponse();
   }
@@ -102,6 +102,10 @@ export async function POST(request: NextRequest) {
   if (!slug) {
     return createInvalidSlugResponse();
   }
+  const amount =
+    typeof body.amount === "number" && Number.isFinite(body.amount)
+      ? Math.max(1, Math.min(10, Math.floor(body.amount)))
+      : 1;
 
   const visitorId = getVisitorId(request);
   const summary = await addClap({
@@ -109,6 +113,7 @@ export async function POST(request: NextRequest) {
     visitorId,
     ip: getClientIp(request),
     userAgent: request.headers.get("user-agent") || "unknown",
+    amount,
   });
 
   if (!summary.configured) {

--- a/components/clap-button.tsx
+++ b/components/clap-button.tsx
@@ -31,6 +31,7 @@ const defaultState: ClapState = {
 
 const HOLD_REPEAT_DELAY_MS = 260
 const HOLD_REPEAT_INTERVAL_MS = 170
+const MAX_BATCH_SIZE = 5
 
 export default function ClapButton({ slug }: { slug: string }) {
   const [state, setState] = useState<ClapState>(defaultState)
@@ -147,7 +148,8 @@ export default function ClapButton({ slug }: { slug: string }) {
     setIsProcessing(true)
 
     while (queuedClapsRef.current > 0) {
-      queuedClapsRef.current -= 1
+      const batchSize = Math.min(MAX_BATCH_SIZE, queuedClapsRef.current)
+      queuedClapsRef.current -= batchSize
 
       try {
         const response = await fetch('/api/claps', {
@@ -155,7 +157,7 @@ export default function ClapButton({ slug }: { slug: string }) {
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ slug }),
+          body: JSON.stringify({ slug, amount: batchSize }),
         })
 
         const data = (await response.json()) as Partial<ClapState> & {
@@ -166,8 +168,8 @@ export default function ClapButton({ slug }: { slug: string }) {
         if (!response.ok) {
           setState((current) => ({
             ...current,
-            total: Math.max(0, current.total - 1),
-            user: Math.max(0, current.user - 1),
+            total: Math.max(0, current.total - batchSize),
+            user: Math.max(0, current.user - batchSize),
           }))
           queuedClapsRef.current = 0
           setError(data.error || "Couldn't register like right now.")
@@ -193,8 +195,8 @@ export default function ClapButton({ slug }: { slug: string }) {
       } catch {
         setState((current) => ({
           ...current,
-          total: Math.max(0, current.total - 1),
-          user: Math.max(0, current.user - 1),
+          total: Math.max(0, current.total - batchSize),
+          user: Math.max(0, current.user - batchSize),
         }))
         queuedClapsRef.current = 0
         setError("Couldn't register like right now.")

--- a/lib/claps-store.test.ts
+++ b/lib/claps-store.test.ts
@@ -74,4 +74,44 @@ describe('claps-store (local mock mode)', () => {
     expect(limitedAt).toBeGreaterThan(0)
     expect(limitedAt).toBeLessThanOrEqual(121)
   })
+
+  it('supports batched clap increments while respecting cap', async () => {
+    const slug = 'batch-post'
+    const visitorId = 'batch-visitor'
+
+    const firstBatch = await addClap({
+      slug,
+      visitorId,
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+      amount: 7,
+    })
+    expect(firstBatch.user).toBe(7)
+    expect(firstBatch.total).toBe(7)
+
+    // Amount is clamped to max batch size (10).
+    const clampedBatch = await addClap({
+      slug,
+      visitorId,
+      ip: '127.0.0.1',
+      userAgent: 'vitest',
+      amount: 60,
+    })
+    expect(clampedBatch.user).toBe(17)
+    expect(clampedBatch.total).toBe(17)
+
+    for (let index = 0; index < 5; index += 1) {
+      await addClap({
+        slug,
+        visitorId,
+        ip: '127.0.0.1',
+        userAgent: 'vitest',
+        amount: 10,
+      })
+    }
+
+    const summary = await getClapSummary(slug, visitorId)
+    expect(summary.user).toBe(50)
+    expect(summary.total).toBe(50)
+  })
 })

--- a/lib/claps-store.ts
+++ b/lib/claps-store.ts
@@ -123,11 +123,13 @@ export async function addClap({
   visitorId,
   ip,
   userAgent,
+  amount = 1,
 }: {
   slug: string
   visitorId: string
   ip: string
   userAgent: string
+  amount?: number
 }): Promise<ClapSummary & { limited?: boolean }> {
   const status = getRedisStatus()
   if (!status.configured) {
@@ -141,6 +143,8 @@ export async function addClap({
 
   const fingerprint = hashFingerprint(`${ip}|${userAgent}`)
   const rlKey = rateLimitKey(slug, fingerprint)
+  const clampedAmount = Math.max(1, Math.min(10, Math.floor(amount)))
+
   if (status.mode === 'local') {
     const now = Date.now()
     const existingRate = localRate.get(rlKey)
@@ -168,9 +172,10 @@ export async function addClap({
       return await getClapSummary(slug, visitorId)
     }
 
-    const nextUserCount = currentUser + 1
+    const allowedAmount = Math.min(clampedAmount, CLAPS_CAP_PER_VISITOR - currentUser)
+    const nextUserCount = currentUser + allowedAmount
     const totalStoreKey = totalKey(slug)
-    const nextTotalCount = (localTotals.get(totalStoreKey) || 0) + 1
+    const nextTotalCount = (localTotals.get(totalStoreKey) || 0) + allowedAmount
     localUsers.set(perUserKey, nextUserCount)
     localTotals.set(totalStoreKey, nextTotalCount)
 
@@ -200,9 +205,10 @@ export async function addClap({
     return await getClapSummary(slug, visitorId)
   }
 
+  const allowedAmount = Math.min(clampedAmount, CLAPS_CAP_PER_VISITOR - currentUser)
   const [newUser, newTotal] = await Promise.all([
-    redis.incr(perUserKey),
-    redis.incr(totalKey(slug)),
+    redis.incrby(perUserKey, allowedAmount),
+    redis.incrby(totalKey(slug), allowedAmount),
   ])
 
   return {


### PR DESCRIPTION
## Summary
- batch clap API writes from hold interactions to reduce request volume
- support incremental `amount` in clap API/store with safe clamping
- preserve 50-like per-user cap while applying batched increments

## Validation
- npm test
- npm run test:smoke:ci
- npm run lint
- npm run build
