### PR TITLE
chore: harden custom link a11y and behavior tests

### DIFF
--- a/components/link.test.tsx
+++ b/components/link.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import CustomLink from './link'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+describe('CustomLink', () => {
+  it('renders internal links without forcing external target behavior', () => {
+    render(<CustomLink href="/blog/posts">Posts</CustomLink>)
+
+    const link = screen.getByRole('link', { name: 'Posts' })
+    expect(link.getAttribute('href')).toBe('/blog/posts')
+    expect(link.getAttribute('target')).toBeNull()
+    expect(link.getAttribute('rel')).toBeNull()
+  })
+
+  it('renders hash links as in-page anchors', () => {
+    render(<CustomLink href="#section-1">Jump</CustomLink>)
+
+    const link = screen.getByRole('link', { name: 'Jump' })
+    expect(link.getAttribute('href')).toBe('#section-1')
+    expect(link.getAttribute('target')).toBeNull()
+  })
+
+  it('renders external links with safe target/rel', () => {
+    render(<CustomLink href="https://example.com">External</CustomLink>)
+
+    const link = screen.getByRole('link', { name: 'External' })
+    expect(link.getAttribute('href')).toBe('https://example.com')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+})

--- a/components/link.tsx
+++ b/components/link.tsx
@@ -1,21 +1,38 @@
-/* eslint-disable jsx-a11y/anchor-has-content */
 import Link from 'next/link'
 import type { LinkProps } from 'next/link'
-import { AnchorHTMLAttributes } from 'react'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
-const CustomLink = ({ href, ...rest }: LinkProps & AnchorHTMLAttributes<HTMLAnchorElement>) => {
-  const isInternalLink = href && href.startsWith('/')
-  const isAnchorLink = href && href.startsWith('#')
+type CustomLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'children'> &
+  Omit<LinkProps, 'href'> & {
+    href: string
+    children: ReactNode
+  }
+
+const CustomLink = ({ href, children, ...rest }: CustomLinkProps) => {
+  const isInternalLink = href.startsWith('/')
+  const isAnchorLink = href.startsWith('#')
 
   if (isInternalLink) {
-    return <Link href={href} {...rest} />
+    return (
+      <Link href={href} {...rest}>
+        {children}
+      </Link>
+    )
   }
 
   if (isAnchorLink) {
-    return <a href={href} {...rest} />
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    )
   }
 
-  return <a target="_blank" rel="noopener noreferrer" href={href} {...rest} />
+  return (
+    <a target="_blank" rel="noopener noreferrer" href={href} {...rest}>
+      {children}
+    </a>
+  )
 }
 
 export default CustomLink


### PR DESCRIPTION
## Summary
- remove broad anchor-content lint suppression from custom link component
- require explicit children and string href in custom link wrapper
- add unit tests for internal, hash, and external link behavior

## Validation
- npm test
- npm run lint
- npm run build