### PR TITLE
bug: use Upstash KV env vars for claps store

### DIFF
--- a/lib/claps-store.ts
+++ b/lib/claps-store.ts
@@ -28,8 +28,8 @@ function getRedisStatus(): ClapStoreStatus {
     return { configured: true, mode: 'local' }
   }
 
-  const url = process.env.UPSTASH_REDIS_REST_URL
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN
+  const url = process.env.UPSTASH_REDIS_REST_KV_URL
+  const token = process.env.UPSTASH_REDIS_REST_KV_REST_API_TOKEN
 
   if (!url || !token) {
     return { configured: false }


### PR DESCRIPTION
## Summary
- Update claps store Redis env resolution to use Upstash KV variable names generated in production.
- This restores clap configuration detection so the like button renders when KV vars are present.

## PR Title
- bug: use Upstash KV env vars for claps store

## Linked Issue
- Closes #53

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Chore / Tooling / CI
- [ ] Documentation only

## Scope
- In scope: `lib/claps-store.ts` env variable names for Redis URL/token.
- Out of scope: fallback support for legacy non-KV names.

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] Additional tests/checks: `npm test`
- [x] Manual smoke checks: confirmed logic path; production smoke to be verified post-deploy.

## Checklist
- [x] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: deployments still using non-KV env names will report claps unavailable.
- Rollback plan: revert commit `938f33a`.

## Migration Notes (if breaking)
- Deployments must set `UPSTASH_REDIS_REST_KV_URL` and `UPSTASH_REDIS_REST_KV_REST_API_TOKEN`.

## Screenshots / Evidence (if UI change)
- Before: like button hidden in prod when only KV vars existed.
- After: claps store is configured with KV vars, enabling like button render.
