### PR TITLE
chore: remove obsolete anchor-is-valid suppression

### DIFF
--- a/layouts/list-layout-with-tags.tsx
+++ b/layouts/list-layout-with-tags.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 'use client'
 
 import { usePathname } from 'next/navigation'


### PR DESCRIPTION
## Summary
- remove obsolete jsx-a11y anchor-is-valid suppression from list layout
- verify file passes lint without the suppression

## Validation
- npm test
- npm run lint
- npm run build