### PR TITLE
bug: fix claps KV REST URL mapping and avoid 500s

### DIFF
--- a/app/api/claps/route.ts
+++ b/app/api/claps/route.ts
@@ -77,7 +77,13 @@ export async function GET(request: NextRequest) {
   }
 
   const visitorId = getVisitorId(request);
-  const summary = await getClapSummary(slug, visitorId);
+  let summary;
+  try {
+    summary = await getClapSummary(slug, visitorId);
+  } catch {
+    const response = createUnavailableResponse(getClapsCapPerVisitor());
+    return withVisitorCookie(response, request, visitorId);
+  }
   const response = summary.configured
     ? NextResponse.json(summary, {
         status: 200,
@@ -108,13 +114,19 @@ export async function POST(request: NextRequest) {
       : 1;
 
   const visitorId = getVisitorId(request);
-  const summary = await addClap({
-    slug,
-    visitorId,
-    ip: getClientIp(request),
-    userAgent: request.headers.get("user-agent") || "unknown",
-    amount,
-  });
+  let summary;
+  try {
+    summary = await addClap({
+      slug,
+      visitorId,
+      ip: getClientIp(request),
+      userAgent: request.headers.get("user-agent") || "unknown",
+      amount,
+    });
+  } catch {
+    const response = createUnavailableResponse(getClapsCapPerVisitor());
+    return withVisitorCookie(response, request, visitorId);
+  }
 
   if (!summary.configured) {
     const response = createUnavailableResponse(getClapsCapPerVisitor());

--- a/lib/claps-store.ts
+++ b/lib/claps-store.ts
@@ -28,7 +28,7 @@ function getRedisStatus(): ClapStoreStatus {
     return { configured: true, mode: 'local' }
   }
 
-  const url = process.env.UPSTASH_REDIS_REST_KV_URL
+  const url = process.env.UPSTASH_REDIS_REST_KV_REST_API_URL
   const token = process.env.UPSTASH_REDIS_REST_KV_REST_API_TOKEN
 
   if (!url || !token) {


### PR DESCRIPTION
## Summary
- Fix claps Redis URL env mapping to use Upstash KV REST API URL key.
- Add defensive error handling in `/api/claps` GET/POST so Redis runtime errors degrade to unavailable response instead of HTTP 500.

## PR Title
- bug: fix claps KV REST URL mapping and avoid 500s

## Linked Issue
- Closes #58

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Chore / Tooling / CI
- [ ] Documentation only

## Scope
- In scope: claps env resolution and API route failure handling.
- Out of scope: fallback support for legacy non-KV names.

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] Additional tests/checks: `npm test`
- [x] Manual smoke checks: validated expected non-500 route behavior by code path; prod check after deploy.

## Checklist
- [x] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: if deployed env values are still invalid, claps will be unavailable (but no 500).
- Rollback plan: revert commit `6062d93`.

## Migration Notes (if breaking)
- Ensure `UPSTASH_REDIS_REST_KV_REST_API_URL` and `UPSTASH_REDIS_REST_KV_REST_API_TOKEN` are set for production.

## Screenshots / Evidence (if UI change)
- Before: `/api/claps` POST could return 500.
- After: route handles backend failures without 500 and uses correct REST URL env key.
