### PR TITLE
bug: prevent clap count jitter during rapid likes

### DIFF
--- a/components/clap-button.test.tsx
+++ b/components/clap-button.test.tsx
@@ -114,6 +114,106 @@ describe('ClapButton', () => {
     })
   })
 
+  it('keeps displayed count monotonic while batched requests are still pending', async () => {
+    let postCallCount = 0
+    let serverState: ClapState = {
+      configured: true,
+      total: 0,
+      user: 0,
+      cap: 50,
+    }
+
+    let resolveFirstPost: (() => void) | null = null
+    let resolveSecondPost: (() => void) | null = null
+
+    const firstPostPromise = new Promise<Response>((resolve) => {
+      resolveFirstPost = () => {
+        serverState = {
+          ...serverState,
+          total: serverState.total + 1,
+          user: serverState.user + 1,
+        }
+        resolve(createJsonResponse(serverState))
+      }
+    })
+
+    const secondPostPromise = new Promise<Response>((resolve) => {
+      resolveSecondPost = () => {
+        serverState = {
+          ...serverState,
+          total: serverState.total + 5,
+          user: serverState.user + 5,
+        }
+        resolve(createJsonResponse(serverState))
+      }
+    })
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = String(input)
+      const method = init?.method || 'GET'
+
+      if (method === 'GET' && url.includes('/api/claps')) {
+        return Promise.resolve(createJsonResponse(serverState))
+      }
+
+      if (method === 'POST' && url.includes('/api/claps')) {
+        postCallCount += 1
+
+        if (postCallCount === 1) {
+          return firstPostPromise
+        }
+
+        if (postCallCount === 2) {
+          return secondPostPromise
+        }
+
+        serverState = {
+          ...serverState,
+          total: serverState.total + 1,
+          user: serverState.user + 1,
+        }
+        return Promise.resolve(createJsonResponse(serverState))
+      }
+
+      throw new Error(`Unhandled fetch request: ${method} ${url}`)
+    })
+
+    render(<ClapButton slug="monotonic-like-post" />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/claps?slug=monotonic-like-post', {
+        method: 'GET',
+      })
+    })
+
+    const button = screen.getByTestId('like-button')
+
+    for (let i = 0; i < 7; i += 1) {
+      fireEvent.keyDown(button, { key: 'Enter' })
+    }
+
+    await waitFor(() => {
+      expect(screen.getByTestId('like-count').textContent).toBe('7')
+    })
+
+    resolveFirstPost?.()
+
+    await waitFor(() => {
+      expect(postCallCount).toBeGreaterThanOrEqual(2)
+    })
+
+    // The first server ack only confirms one clap, but UI should remain at optimistic 7.
+    await waitFor(() => {
+      expect(screen.getByTestId('like-count').textContent).toBe('7')
+    })
+
+    resolveSecondPost?.()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('like-count').textContent).toBe('7')
+    })
+  })
+
   it('does not send POST requests when visitor has reached cap', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const url = String(input)

--- a/components/clap-button.tsx
+++ b/components/clap-button.tsx
@@ -179,8 +179,10 @@ export default function ClapButton({ slug }: { slug: string }) {
 
         setState((current) => ({
           configured: data.configured ?? current.configured,
-          total: typeof data.total === 'number' ? data.total : current.total,
-          user: typeof data.user === 'number' ? data.user : current.user,
+          // Keep optimistic UI monotonic while queued claps are still in flight.
+          total:
+            typeof data.total === 'number' ? Math.max(current.total, data.total) : current.total,
+          user: typeof data.user === 'number' ? Math.max(current.user, data.user) : current.user,
           cap: typeof data.cap === 'number' ? data.cap : current.cap,
         }))
 


### PR DESCRIPTION
## Summary
- Keep clap count monotonic on successful server acks during rapid/held likes.
- Add a regression test that verifies count does not dip after a partial ack while queued claps remain.

## PR Title
- bug: prevent clap count jitter during rapid likes

## Linked Issue
- Closes #60

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Chore / Tooling / CI
- [ ] Documentation only

## Scope
- In scope: clap button success-state merge behavior and related component tests.
- Out of scope: backend clap semantics and rate limit rules.

## Validation
- [x] `npm run lint`
- [ ] `npm run build`
- [x] Additional tests/checks: `npm run -s test -- components/clap-button.test.tsx` and `npm run -s test -- lib/claps-store.test.ts app/api/claps/route.test.ts`
- [x] Manual smoke checks: logic verified for non-decreasing UI count during in-flight batches.

## Checklist
- [x] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: minimal; success path only and error rollback behavior unchanged.
- Rollback plan: Revert commit `55cd4f5`.

## Migration Notes (if breaking)
- N/A

## Screenshots / Evidence (if UI change)
- Before: count could briefly dip during rapid likes.
- After: count remains monotonic while requests settle.
