### PR TITLE
chore: sync upskill runbook with analyzer workflow

### DIFF
--- a/docs/runbooks/codex-skills.md
+++ b/docs/runbooks/codex-skills.md
@@ -4,6 +4,7 @@ This repository expects these custom skills to be installed in the user Codex ho
 
 - `site-maintenance`
 - `ga-seo-strategy-report`
+- `upskill`
 
 Skill path:
 - `$CODEX_HOME/skills` (fallback: `$HOME/.codex/skills`)
@@ -26,9 +27,21 @@ Optional:
 1. Confirm skill scripts exist:
 - `$CODEX_HOME/skills/ga-seo-strategy-report/scripts/ga4_seo_strategy_report.py`
 - `$CODEX_HOME/skills/ga-seo-strategy-report/scripts/check_ga4_setup.sh`
+- `$CODEX_HOME/skills/upskill/scripts/analyze_usage.py`
 2. Load env config: `source .env.local`
 3. Run setup check: `./scripts/ga-seo-check.sh`
 4. Run report: `./scripts/ga-seo-report.sh`
+
+## Upskill usage (12-hour maintenance runs)
+
+Use this analyzer command to rank recent skill friction and choose patch targets:
+
+```bash
+python3 "$CODEX_HOME/skills/upskill/scripts/analyze_usage.py" \
+  --hours 12 \
+  --codex-home "$CODEX_HOME" \
+  --skills-dir "$CODEX_HOME/skills"
+```
 
 ## Wrapper scripts in this repo
 


### PR DESCRIPTION
## Summary
- Add `upskill` to the documented required local skills.
- Add the 12-hour `upskill` analyzer command used by maintenance automations.
- Align runbook guidance with existing `scripts/agent-health-check.sh` behavior.

## PR Title
- Format: `feat|bug|chore: <short description>`
- Example: `feat: add newsletter CTA status fallback`

## Linked Linear
- Outcome ticket (optional): N/A

## Linked Issue
- Closes #67

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Chore / Tooling / CI
- [x] Documentation only

## Scope
- In scope: Codex skills runbook sync for upskill references.
- Out of scope: skill source-code changes under `$CODEX_HOME/skills`, CI behavior changes.

## Validation
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] Additional tests/checks: manual diff review against `scripts/agent-health-check.sh`
- [ ] Manual smoke checks: N/A (docs-only)

## Checklist
- [ ] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: Documentation drift if skill workflow changes again.
- Rollback plan: Revert this commit.

## Migration Notes (if breaking)
- N/A

## Screenshots / Evidence (if UI change)
- Before: N/A
- After: N/A
