### PR TITLE
chore: standardize content handoff and publish checklist

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -19,3 +19,4 @@ This is the single entry point for operations/workflow guidance in this reposito
 
 - [Blog Content Handoff Runbook](./content-handoff.md)
 - [Collaborator Submission Prompt](./templates/blog-collaborator-submission-prompt.md)
+- [Blog Handoff + Pre-Publish Checklist](./templates/blog-publish-checklist.md)

--- a/docs/runbooks/content-handoff.md
+++ b/docs/runbooks/content-handoff.md
@@ -1,18 +1,61 @@
 # Blog Content Handoff Runbook
 
-This runbook covers importing collaborator-provided blog content into `data/blog/*.mdx` without editorial rewriting.
+This runbook standardizes collaborator handoff artifacts and pre-publish checks so posts do not bounce back for missing metadata or launch context.
 
 ## Scope
 
-- Collaborator submits exactly one markdown document.
-- Technical import handles validation and path/format normalization only.
-- Semantic rewriting of the article is out of scope.
+- Covers importing collaborator-provided blog content into `data/blog/*.mdx` without editorial rewriting.
+- Defines required handoff package artifacts for both:
+  - backposts (republish/adapt existing content)
+  - net-new posts (original content for this site)
+- Defines pre-publish metadata, publishing, and distribution checks.
 
-## Canonical collaborator contract
+## Canonical templates
 
-Use this prompt as the single source of truth for contributor submission format:
+- Collaborator submission format:
+  - `docs/runbooks/templates/blog-collaborator-submission-prompt.md`
+- Handoff + pre-publish checklist:
+  - `docs/runbooks/templates/blog-publish-checklist.md`
 
-- `docs/runbooks/templates/blog-collaborator-submission-prompt.md`
+## Required handoff artifacts (strict)
+
+Every post handoff must include all artifacts below before import starts.
+
+1. `Post manuscript` (required)
+- One markdown document that follows the collaborator prompt exactly.
+- Must pass `npm run blog:handoff:validate -- <input.md>`.
+
+2. `Handoff checklist` (required)
+- Copy `docs/runbooks/templates/blog-publish-checklist.md`.
+- Complete every section marked required.
+- Declare `Post type` as either `Backpost` or `Net-new`.
+
+3. `Asset references` (required)
+- Provide final or draft image references for each `[[IMAGE: ...]]` placeholder.
+- Identify whether visuals are new, reused, or pending.
+
+4. `Distribution plan` (required)
+- At least one channel and owner must be assigned before publish.
+- Include target publish date and timezone.
+
+## Post-type requirements
+
+Both post types require the same manuscript metadata (`slug`, `title`, `summary`, `date`, `lastmod`) and a completed checklist, plus the post-type-specific fields below.
+
+### Backpost
+
+- `Original URL` and source publication name.
+- `Original published date`.
+- `Canonical strategy`:
+  - keep original canonical, or
+  - canonical to this site (must be explicitly approved).
+- `Reuse rights confirmed` (text, image, diagrams).
+
+### Net-new
+
+- `Target publish date` and owner.
+- `Distribution owner` and channels.
+- `Primary CTA` (newsletter, contact, product, etc).
 
 ## Import commands
 
@@ -47,6 +90,23 @@ npm run blog:handoff:import -- scripts/blog-handoff/samples/valid-collaborator-h
   - trimmed to max 80 chars
   - fallback: `untitled-post-YYYYMMDD`
 - Summary must be plain text, 1-2 sentences, max 180 characters
+
+## Pre-publish checklist (required)
+
+Before publish, confirm all checks in `docs/runbooks/templates/blog-publish-checklist.md` are complete, including:
+
+1. Metadata checks
+- Title/H1 match, summary limits, slug normalization, publish date accuracy.
+
+2. Content checks
+- Placeholder replacement complete, links/images valid, no TODO/TBD/lorem text.
+
+3. Publish checks
+- Correct path in `data/blog/<slug>.mdx`, social/OG coverage verified, owner sign-off complete.
+
+4. Distribution checks
+- Announce channels, owners, and timing set.
+- Backpost attribution/canonical details explicitly confirmed.
 
 ## Output and post-import steps
 

--- a/docs/runbooks/templates/blog-collaborator-submission-prompt.md
+++ b/docs/runbooks/templates/blog-collaborator-submission-prompt.md
@@ -12,6 +12,7 @@ Requirements:
 - Do not include TODO/TBD/lorem placeholders.
 - Keep meaning, voice, and paragraph order intact.
 - Only light readability formatting is allowed.
+- The handoff owner must also complete `docs/runbooks/templates/blog-publish-checklist.md`.
 
 Template to follow:
 
@@ -34,4 +35,3 @@ If a visual is required, include only one of these placeholders on its own line:
 - `[[MERMAID: short-description]]`
 
 Do not generate image files or Mermaid code.
-

--- a/docs/runbooks/templates/blog-publish-checklist.md
+++ b/docs/runbooks/templates/blog-publish-checklist.md
@@ -1,0 +1,64 @@
+# Blog Handoff + Pre-Publish Checklist
+
+Use this checklist for every post before publish. Duplicate it into the issue/PR description and fill all required fields.
+
+## Post Summary
+
+- [ ] Post type selected: `Backpost` or `Net-new`
+- [ ] Owner assigned
+- [ ] Target publish date + timezone set
+
+## Required Handoff Artifacts
+
+- [ ] Manuscript included as one markdown file using `===METADATA===` format
+- [ ] `npm run blog:handoff:validate -- <input.md>` passed
+- [ ] Asset references provided for all `[[IMAGE: ...]]` / `[[MERMAID: ...]]` placeholders
+- [ ] Distribution plan added with channels + owners
+
+## Metadata Checks
+
+- [ ] `slug` is lowercase ASCII and normalized
+- [ ] `title` matches body H1 exactly
+- [ ] `summary` is plain text, 1-2 sentences, <= 180 chars
+- [ ] `date` is valid (`YYYY-MM-DD`)
+- [ ] `lastmod` is valid (`YYYY-MM-DD`) and >= `date` when updates were made
+
+## Content Readiness
+
+- [ ] No frontmatter in collaborator handoff file
+- [ ] No HTML/JSX tags in handoff body
+- [ ] No tags section in body
+- [ ] No TODO/TBD/lorem placeholders
+- [ ] All placeholders resolved before publish
+- [ ] External/internal links tested
+
+## Post-Type Specific Checks
+
+### Backpost
+
+- [ ] Original URL recorded
+- [ ] Original published date recorded
+- [ ] Canonical strategy selected and verified
+- [ ] Reuse rights confirmed for text/images/diagrams
+- [ ] Attribution line reviewed (if required)
+
+### Net-new
+
+- [ ] Publish owner confirmed
+- [ ] Primary CTA confirmed
+- [ ] Distribution channels selected
+- [ ] Distribution owner confirmed
+
+## Publish and Distribution
+
+- [ ] Final file exists at `data/blog/<slug>.mdx`
+- [ ] Referenced images exist under `public/static/images/<slug>/`
+- [ ] Publish announcement copy drafted
+- [ ] Channel schedule set (for example: LinkedIn, X, newsletter)
+- [ ] Post-publish check owner assigned
+
+## Sign-off
+
+- [ ] Content owner approved
+- [ ] Technical reviewer approved
+- [ ] Ready to publish


### PR DESCRIPTION
## Summary
- Standardized the blog content handoff process with strict required artifacts before import.
- Added a reusable pre-publish checklist covering metadata, publish readiness, and distribution checks.
- Added explicit post-type gates so both backposts and net-new posts follow the same baseline plus specific requirements.

## PR Title
- Format: `feat|bug|chore: <short description>`
- Title used: `chore: standardize content handoff and publish checklist`

## Linked Linear
- Outcome ticket (optional): BEA-2

## Linked Issue
- Closes #73

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Chore / Tooling / CI
- [x] Documentation only

## Scope
- In scope: `docs/runbooks/content-handoff.md`, runbook index updates, and a new standardized checklist template.
- Out of scope: importer logic changes and automated enforcement of checklist completion.

## Validation
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] Additional tests/checks: `npm run blog:handoff:smoke`
- [x] Manual smoke checks: docs readability/flow review for handoff and publish steps.

## Checklist
- [ ] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: Process adoption risk if checklist is not used consistently.
- Rollback plan: Revert commit `20099a6`.

## Migration Notes (if breaking)
- N/A

## Screenshots / Evidence (if UI change)
- Before: N/A
- After: N/A
