### PR TITLE
chore: optimize homepage server path and caching

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -15,6 +15,10 @@ This is the single entry point for operations/workflow guidance in this reposito
 
 - [Newsletter API Observability Runbook](./newsletter-observability.md)
 
+## Performance
+
+- [Performance Cache Runbook](./performance-cache.md)
+
 ## Content Handoff
 
 - [Blog Content Handoff Runbook](./content-handoff.md)

--- a/docs/runbooks/performance-cache.md
+++ b/docs/runbooks/performance-cache.md
@@ -1,0 +1,46 @@
+# Performance Cache Runbook
+
+This runbook defines the response-cache strategy for high-traffic content routes.
+
+## Goal
+
+Reduce repeat-request latency (especially TTFB) for public content routes while keeping content freshness acceptable.
+
+## Current Policy
+
+The following routes send:
+
+`Cache-Control: public, s-maxage=600, stale-while-revalidate=86400`
+
+- `/`
+- `/about`
+- `/blog`
+- `/blog/posts`
+- `/blog/posts/:path*`
+- `/blog/tags`
+- `/blog/tags/:path*`
+- `/sitemap.xml`
+- `/robots.txt`
+
+## Why
+
+- `s-maxage=600`: edge cache can serve for 10 minutes before revalidation.
+- `stale-while-revalidate=86400`: stale responses can be served while cache refresh happens in background.
+
+This helps smooth latency spikes and cold starts for public pages.
+
+## Verify
+
+Run:
+
+```bash
+curl -I https://ankushp.com/
+curl -I https://ankushp.com/blog
+curl -I https://ankushp.com/blog/posts/the-missing-layer-in-your-ai-stack-intermediate-knowledge
+```
+
+Confirm `Cache-Control` matches the policy above.
+
+## Rollback
+
+Revert the `contentCacheHeaders` additions in `next.config.js` and redeploy.

--- a/next.config.js
+++ b/next.config.js
@@ -56,6 +56,13 @@ const securityHeaders = [
   },
 ]
 
+const contentCacheHeaders = [
+  {
+    key: 'Cache-Control',
+    value: 'public, s-maxage=600, stale-while-revalidate=86400',
+  },
+]
+
 /**
  * @type {import('next/dist/next-server/server/config').NextConfig}
  **/
@@ -81,6 +88,42 @@ module.exports = () => {
         {
           source: '/(.*)',
           headers: securityHeaders,
+        },
+        {
+          source: '/',
+          headers: contentCacheHeaders,
+        },
+        {
+          source: '/about',
+          headers: contentCacheHeaders,
+        },
+        {
+          source: '/blog',
+          headers: contentCacheHeaders,
+        },
+        {
+          source: '/blog/posts',
+          headers: contentCacheHeaders,
+        },
+        {
+          source: '/blog/posts/:path*',
+          headers: contentCacheHeaders,
+        },
+        {
+          source: '/blog/tags',
+          headers: contentCacheHeaders,
+        },
+        {
+          source: '/blog/tags/:path*',
+          headers: contentCacheHeaders,
+        },
+        {
+          source: '/sitemap.xml',
+          headers: contentCacheHeaders,
+        },
+        {
+          source: '/robots.txt',
+          headers: contentCacheHeaders,
         },
       ]
     },


### PR DESCRIPTION
## Summary
- add explicit edge cache headers for high-traffic content routes (`/`, `/about`, blog routes, sitemap, robots)
- codify cache strategy in a performance runbook with verification commands
- index the new performance runbook from operations docs

## Linked Linear
- BEA-1 (optional)

## Linked Issue
- Closes #71

## Validation
- npm run lint
- npm test
- npm run build
