### PR TITLE
chore: add weekly content measurement workflow

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -9,6 +9,7 @@ This is the single entry point for operations/workflow guidance in this reposito
 ## Codex Skills
 
 - [Codex Skills Runbook](./codex-skills.md)
+- [Weekly Content Measurement Runbook](./weekly-content-measurement.md)
 - Health check command: `npm run agent:health`
 - [Night Runner Runbook](./night-runner.md)
 

--- a/docs/runbooks/codex-skills.md
+++ b/docs/runbooks/codex-skills.md
@@ -31,6 +31,7 @@ Optional:
 2. Load env config: `source .env.local`
 3. Run setup check: `./scripts/ga-seo-check.sh`
 4. Run report: `./scripts/ga-seo-report.sh`
+5. Run weekly snapshot: `./scripts/ga-weekly-dashboard.sh`
 
 ## Upskill usage (12-hour maintenance runs)
 
@@ -47,6 +48,7 @@ python3 "$CODEX_HOME/skills/upskill/scripts/analyze_usage.py" \
 
 - `scripts/ga-seo-check.sh`: validates GA skill readiness from current env.
 - `scripts/ga-seo-report.sh`: executes the GA report skill with sensible defaults.
+- `scripts/ga-weekly-dashboard.sh`: creates a dated weekly snapshot under `output/ga-weekly/`.
 - `scripts/agent-health-check.sh`: validates installed skills, script syntax/smoke checks, and local automation TOML/cwd/rrule sanity.
 
 ## Notes

--- a/docs/runbooks/weekly-content-measurement.md
+++ b/docs/runbooks/weekly-content-measurement.md
@@ -1,0 +1,55 @@
+# Weekly Content Measurement Runbook
+
+This runbook defines a weekly measurement cadence that ties content output to outcomes.
+
+## Goal
+
+Make weekly content decisions from consistent evidence across traffic quality, subscriber growth, and topic performance.
+
+## Inputs
+
+- GA readiness check: `./scripts/ga-seo-check.sh`
+- Weekly snapshot command: `./scripts/ga-weekly-dashboard.sh`
+- Optional path prefix override: `GA4_PATH_PREFIX=/blog`
+
+## Weekly KPI Dashboard
+
+Track this dashboard once per week from the generated snapshot in `output/ga-weekly/<YYYY-MM-DD>/`.
+
+| KPI | Why it matters | Source |
+| --- | --- | --- |
+| Organic blog sessions | Measures top-of-funnel qualified discovery | `summary.md` + `raw.json` |
+| Engaged sessions per post | Measures reader quality, not just clicks | `raw.json` |
+| Top post CTR trend | Identifies topics/headlines winning distribution | `summary.md` |
+| New subscriber starts | Connects content output to conversion | newsletter metrics + weekly notes |
+| Top topic clusters | Guides next-week editorial planning | `summary.md` |
+
+## Weekly Procedure
+
+1. Run readiness check: `./scripts/ga-seo-check.sh`.
+2. Generate weekly snapshot: `./scripts/ga-weekly-dashboard.sh`.
+3. Review `output/ga-weekly/<YYYY-MM-DD>/summary.md` and extract:
+   - top-performing posts,
+   - underperforming posts,
+   - topic cluster movement.
+4. Record subscriber movement from your newsletter/CRM source in the same weekly note.
+5. Decide next-week actions:
+   - create 1-2 follow-up topics from winners,
+   - refresh 1 weak post with high potential,
+   - update distribution angle/channel where CTR dropped.
+
+## Review Cadence
+
+- Frequency: once per week.
+- Owner: content operator on duty.
+- Review artifact: one dated note linked to `output/ga-weekly/<YYYY-MM-DD>/`.
+
+## Evidence and Retention
+
+- Generated artifacts in `output/` are local and git-ignored.
+- Keep a dated decision log in your planning system, with links to snapshot files.
+
+## Risk and Rollback
+
+- Risk: missing GA credentials can block snapshot generation.
+- Rollback: no production impact; remove runbook/script commit to revert process changes.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:smoke:headed": "playwright test --headed --project=chromium",
     "test:smoke:ci": "cross-env CI=1 playwright test --project=chromium --reporter=line",
     "agent:health": "bash ./scripts/agent-health-check.sh",
+    "agent:ga:weekly": "bash ./scripts/ga-weekly-dashboard.sh",
     "agent:night:run": "bash ./scripts/night-runner.sh",
     "agent:night:install-cron": "bash ./scripts/install-night-runner-cron.sh",
     "blog:handoff:validate": "node scripts/blog-handoff-import.mjs validate",

--- a/scripts/ga-weekly-dashboard.sh
+++ b/scripts/ga-weekly-dashboard.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+STAMP="$(date +%F)"
+OUT_DIR="${1:-output/ga-weekly/${STAMP}}"
+
+mkdir -p "$OUT_DIR"
+
+GA4_START_DATE="${GA4_START_DATE:-7daysAgo}" \
+GA4_END_DATE="${GA4_END_DATE:-yesterday}" \
+./scripts/ga-seo-report.sh "$OUT_DIR/summary.md" "$OUT_DIR/raw.json"
+
+echo "Weekly dashboard snapshot written:"
+echo "  $OUT_DIR/summary.md"
+echo "  $OUT_DIR/raw.json"


### PR DESCRIPTION
## Summary
- Added a weekly measurement runbook to standardize KPI review and decision cadence for content performance.
- Added `scripts/ga-weekly-dashboard.sh` to generate dated weekly GA snapshot artifacts.
- Updated runbook index and Codex skills runbook with the new workflow.
- Added npm shortcut: `npm run agent:ga:weekly`.

## PR Title
- Format: `feat|bug|chore: <short description>`
- This PR: `chore: add weekly content measurement workflow`

## Linked Linear
- Outcome ticket (optional): `BEA-7`

## Linked Issue
- Closes #80

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Chore / Tooling / CI
- [x] Documentation only

## Scope
- In scope: weekly measurement runbook + wrapper script + docs/script wiring.
- Out of scope: analytics backend changes, production runtime behavior changes, dashboard UI changes.

## Validation
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] Additional tests/checks: `bash -n scripts/ga-weekly-dashboard.sh scripts/ga-seo-report.sh scripts/ga-seo-check.sh`
- [x] Manual smoke checks: `./scripts/ga-seo-check.sh` (passed with dependency warning); `./scripts/ga-weekly-dashboard.sh` (fails locally when repo virtualenv `.venv` is missing).

## Checklist
- [ ] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: Operator confusion if local Python venv is not created before running weekly snapshot wrapper.
- Rollback plan: Revert commit `53629a1`.

## Migration Notes (if breaking)
- N/A

## Screenshots / Evidence (if UI change)
- Before: N/A
- After: N/A
