### PR TITLE
chore: stabilize migration branch and document next16 blocker

### DIFF
--- a/components/comments.tsx
+++ b/components/comments.tsx
@@ -1,8 +1,15 @@
 'use client'
 
-import { Comments as CommentsComponent } from 'pliny/comments'
+import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import siteMetadata from '@/data/siteMetadata'
+
+const CommentsComponent = dynamic(
+  () => import('pliny/comments').then((mod) => mod.Comments),
+  {
+    ssr: false,
+  }
+)
 
 export default function Comments({ slug }: { slug: string }) {
   const [loadComments, setLoadComments] = useState(false)

--- a/docs/specs/next16-migration/blockers.md
+++ b/docs/specs/next16-migration/blockers.md
@@ -1,0 +1,26 @@
+# Next.js 16 Migration Blockers
+
+## Active blocker: static prerender crash on MDX routes
+
+- Tracking issue: #90
+- Symptom: `npm run build` fails with `ReactCurrentDispatcher` undefined when removing temporary dynamic fallbacks from MDX-backed routes.
+- Affected routes:
+  - `/about`
+  - `/blog/posts/[...slug]`
+
+## Current stabilization state
+
+- Temporary fallback remains in place to keep build green:
+  - `export const dynamic = "force-dynamic"` in the two affected routes.
+- Baseline migration remains merged and passing with fallback enabled.
+
+## Required follow-up to close migration
+
+1. Identify and fix root incompatibility in MDX render path under Next.js 16 static prerender.
+2. Remove temporary `force-dynamic` flags.
+3. Confirm `npm run lint`, `npm test`, and `npm run build` pass.
+4. Smoke-check `/about` and multiple `/blog/posts/[slug]` pages.
+
+## Related work
+
+- Outcome planning issue for post-migration analytics investigation: #89.


### PR DESCRIPTION
## Summary
- Defers comments provider loading with a client-only dynamic import to reduce unnecessary server bundle pressure on routes where comments are disabled by default.
- Adds an explicit migration blocker note for Next.js 16 static prerender crash tracking and closeout plan.
- Keeps current production behavior stable while documenting the remaining migration blocker path.

## PR Title
- Format: `feat|bug|chore: <short description>`
- This PR: `chore: stabilize migration branch and document next16 blocker`

## Linked Linear
- Outcome ticket (optional): N/A

## Linked Issue
- Closes #91
- Refs #90
- Refs #89

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Chore / Tooling / CI
- [ ] Documentation only

## Scope
- In scope: lazy-load comments provider component, add Next 16 blocker documentation.
- Out of scope: fixing the static prerender blocker root cause (#90), removing dynamic fallbacks.

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] Additional tests/checks: `npm test`
- [x] Manual smoke checks: comments still load on click; migration blocker note reviewed.

## Checklist
- [ ] Breaking change? If yes, document migration notes below.
- [x] Security impact reviewed.
- [x] Performance impact reviewed.
- [x] Docs updated (or not needed).

## Risk and Rollback
- Risk level: Low
- Main risks: minimal; comments component import path changed to dynamic client-only load.
- Rollback plan: Revert commit `cea5467`.

## Migration Notes (if breaking)
- N/A

## Screenshots / Evidence (if UI change)
- Before: N/A
- After: N/A
