### PR TITLE
bug: prevent production client runtime crash

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -6,8 +6,9 @@ import Link from './link'
 import MobileNav from './mobile-nav'
 import ThemeSwitch from './theme-switch'
 import { usePathname } from 'next/navigation'
-import { KBarSearchProvider, KBarSearchProps } from './kbar/kbar'
-import KBarButton from './kbar/kbar-button'
+import dynamic from 'next/dynamic'
+
+const BlogSearch = dynamic(() => import('./kbar/blog-search'), { ssr: false })
 
 const NavLinks = ({ links }) => {
   return (
@@ -55,11 +56,7 @@ const Header = () => {
       </div>
       <div className="flex items-center space-x-4 leading-5 sm:space-x-6">
         <NavLinks links={isBlogPage ? blogNavLinks : homeNavLinks} />
-        {isBlogPage && siteMetadata.search?.provider === 'kbar' && (
-          <KBarSearchProvider kbarConfig={siteMetadata.search.kbarConfig as KBarSearchProps}>
-            <KBarButton />
-          </KBarSearchProvider>
-        )}
+        {isBlogPage && siteMetadata.search?.provider === 'kbar' && <BlogSearch />}
         <ThemeSwitch />
         <MobileNav />
       </div>

--- a/components/home/home-3d-error-boundary.tsx
+++ b/components/home/home-3d-error-boundary.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+
+type Home3DErrorBoundaryProps = {
+  children: ReactNode;
+  fallback: ReactNode;
+};
+
+type Home3DErrorBoundaryState = {
+  hasError: boolean;
+};
+
+class Home3DErrorBoundary extends Component<Home3DErrorBoundaryProps, Home3DErrorBoundaryState> {
+  state: Home3DErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Home 3D scene failed to render.", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default Home3DErrorBoundary;

--- a/components/home/home-3d-scene-shell.tsx
+++ b/components/home/home-3d-scene-shell.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 
+import Home3DErrorBoundary from "@/components/home/home-3d-error-boundary";
 import Home3DFallback from "@/components/home/home-3d-fallback";
 
 const Home3DScene = dynamic(() => import("@/components/home/home-3d-scene"), {
@@ -10,5 +11,9 @@ const Home3DScene = dynamic(() => import("@/components/home/home-3d-scene"), {
 });
 
 export default function Home3DSceneShell() {
-  return <Home3DScene />;
+  return (
+    <Home3DErrorBoundary fallback={<Home3DFallback />}>
+      <Home3DScene />
+    </Home3DErrorBoundary>
+  );
 }

--- a/components/kbar/blog-search.tsx
+++ b/components/kbar/blog-search.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import siteMetadata from '@/data/siteMetadata'
+import { KBarSearchProvider, KBarSearchProps } from './kbar'
+import KBarButton from './kbar-button'
+
+const BlogSearch = () => {
+  if (siteMetadata.search?.provider !== 'kbar' || !siteMetadata.search.kbarConfig) {
+    return null
+  }
+
+  return (
+    <KBarSearchProvider kbarConfig={siteMetadata.search.kbarConfig as KBarSearchProps}>
+      <KBarButton />
+    </KBarSearchProvider>
+  )
+}
+
+export default BlogSearch

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "github-slugger": "^1.4.0",
         "gray-matter": "^4.0.3",
         "image-size": "^1.1.1",
-        "kbar": "^0.1.0-beta.45",
+        "kbar": "0.1.0-beta.45",
         "lucide-react": "^0.464.0",
         "mermaid": "^11.4.1",
         "next": "^16.1.6",
@@ -14873,9 +14873,9 @@
       }
     },
     "node_modules/kbar": {
-      "version": "0.1.0-beta.48",
-      "resolved": "https://registry.npmjs.org/kbar/-/kbar-0.1.0-beta.48.tgz",
-      "integrity": "sha512-HD5A1dqfK6XGeoH4fRWTmRt4y76sDbtGxY4Dh2xNa5MYtvtKsqfz+nRZ0tKgcrjjGYN4rf5TLXMJuiE7Pb8rXg==",
+      "version": "0.1.0-beta.45",
+      "resolved": "https://registry.npmjs.org/kbar/-/kbar-0.1.0-beta.45.tgz",
+      "integrity": "sha512-kXvjthqPLoWZXlxLJPrFKioskNdQv1O3Ukg5mqq2ExK3Ix1qvYT3W/ACDRIv/e/CHxPWZoTriB4oFbQ6UCSX5g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-portal": "^1.0.1",
@@ -14885,8 +14885,8 @@
         "tiny-invariant": "^1.2.0"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/kbar/node_modules/react-virtual": {
@@ -17399,38 +17399,6 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
-    },
-    "node_modules/pliny/node_modules/kbar": {
-      "version": "0.1.0-beta.45",
-      "resolved": "https://registry.npmjs.org/kbar/-/kbar-0.1.0-beta.45.tgz",
-      "integrity": "sha512-kXvjthqPLoWZXlxLJPrFKioskNdQv1O3Ukg5mqq2ExK3Ix1qvYT3W/ACDRIv/e/CHxPWZoTriB4oFbQ6UCSX5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-portal": "^1.0.1",
-        "fast-equals": "^2.0.3",
-        "fuse.js": "^6.6.2",
-        "react-virtual": "^2.8.2",
-        "tiny-invariant": "^1.2.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/pliny/node_modules/kbar/node_modules/react-virtual": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.4.tgz",
-      "integrity": "sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==",
-      "funding": [
-        "https://github.com/sponsors/tannerlinsley"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@reach/observe-rect": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.3 || ^17.0.0"
-      }
     },
     "node_modules/pliny/node_modules/unist-util-is": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "github-slugger": "^1.4.0",
     "gray-matter": "^4.0.3",
     "image-size": "^1.1.1",
-    "kbar": "^0.1.0-beta.45",
+    "kbar": "0.1.0-beta.45",
     "lucide-react": "^0.464.0",
     "mermaid": "^11.4.1",
     "next": "^16.1.6",
@@ -93,6 +93,9 @@
     "prettier-plugin-tailwindcss": "^0.4.1",
     "typescript": "^5.1.3",
     "vitest": "^1.6.0"
+  },
+  "overrides": {
+    "kbar": "0.1.0-beta.45"
   },
   "resolutions": {
     "@opentelemetry/api": "1.4.1",

--- a/tests/smoke/blog.smoke.spec.ts
+++ b/tests/smoke/blog.smoke.spec.ts
@@ -1,6 +1,19 @@
 import { expect, test } from '@playwright/test'
 
 test.describe('blog smoke suite', () => {
+  test('home page loads without client runtime errors', async ({ page }) => {
+    const runtimeErrors: string[] = []
+    page.on('pageerror', (error) => {
+      runtimeErrors.push(error.message)
+    })
+
+    await page.goto('/')
+    await expect(page.getByRole('heading', { name: /Ankush Patel/i })).toBeVisible()
+    await page.waitForTimeout(500)
+
+    expect(runtimeErrors, `unexpected client errors: ${runtimeErrors.join(' | ')}`).toHaveLength(0)
+  })
+
   test('blog landing page loads', async ({ page }) => {
     await page.goto('/blog')
 


### PR DESCRIPTION
## Summary
- force a single resolved `kbar` version (`0.1.0-beta.45`) via dependency pin + npm override to remove duplicate runtime paths
- lazy-load blog search UI so `kbar` code is only loaded on blog routes
- add a homepage 3D error boundary so R3F runtime faults degrade to safe fallback instead of crashing the app
- extend smoke tests with a homepage runtime guard

## Linked Issue
Closes #95

## Validation
- npm run lint
- npm run build
- npm run test:smoke:ci
- reproduced prior crash signatures (`ReactCurrentBatchConfig` / `ReactCurrentOwner`) before patch and confirmed homepage now renders safely

## Risk and Rollback
- Risk: low-medium (dependency graph + client boundary changes)
- Rollback: revert commit `622f89a`
