### PR TITLE
bug: stabilize production by disabling home 3D runtime

### DIFF
--- a/components/home/home-3d-scene-shell.tsx
+++ b/components/home/home-3d-scene-shell.tsx
@@ -1,19 +1,7 @@
 "use client";
 
-import dynamic from "next/dynamic";
-
-import Home3DErrorBoundary from "@/components/home/home-3d-error-boundary";
 import Home3DFallback from "@/components/home/home-3d-fallback";
 
-const Home3DScene = dynamic(() => import("@/components/home/home-3d-scene"), {
-  ssr: false,
-  loading: () => <Home3DFallback />,
-});
-
 export default function Home3DSceneShell() {
-  return (
-    <Home3DErrorBoundary fallback={<Home3DFallback />}>
-      <Home3DScene />
-    </Home3DErrorBoundary>
-  );
+  return <Home3DFallback />;
 }


### PR DESCRIPTION
## Summary
- temporarily disable homepage 3D runtime module load and render static home fallback
- prevents client-side React internals crash path from `@react-three/fiber` on Next 16
- keeps site usable while compatibility remediation is handled in #97

## Linked Issue
Refs #97

## Validation
- npm run lint
- npm run build
- npm run test:smoke:ci

## Risk and Rollback
- Risk: low (isolated homepage visual fallback)
- Rollback: revert commit `bdfa5ca`
